### PR TITLE
[Release] DEP-166: v2.3.1

### DIFF
--- a/Samples/Carthage/Sample.xcodeproj/project.pbxproj
+++ b/Samples/Carthage/Sample.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;
@@ -430,7 +430,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;

--- a/Samples/CocoaPods/Sample.xcodeproj/project.pbxproj
+++ b/Samples/CocoaPods/Sample.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;
@@ -339,7 +339,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;

--- a/Specs/Carthage/YotiCommon.json
+++ b/Specs/Carthage/YotiCommon.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiCommon.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiCommon.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiCommon.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiCommon.zip",
 }

--- a/Specs/Carthage/YotiDocumentCapture.json
+++ b/Specs/Carthage/YotiDocumentCapture.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiDocumentCapture.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiDocumentCapture.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiDocumentCapture.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiDocumentCapture.zip",
 }

--- a/Specs/Carthage/YotiFoundation.json
+++ b/Specs/Carthage/YotiFoundation.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiFoundation.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiFoundation.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiFoundation.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiFoundation.zip",
 }

--- a/Specs/Carthage/YotiNetwork.json
+++ b/Specs/Carthage/YotiNetwork.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiNetwork.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiNetwork.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiNetwork.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiNetwork.zip",
 }

--- a/Specs/Carthage/YotiSDKCommon.json
+++ b/Specs/Carthage/YotiSDKCommon.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiSDKCommon.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiSDKCommon.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiSDKCommon.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiSDKCommon.zip",
 }

--- a/Specs/Carthage/YotiSDKCore.json
+++ b/Specs/Carthage/YotiSDKCore.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiSDKCore.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiSDKCore.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiSDKCore.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiSDKCore.zip",
 }

--- a/Specs/Carthage/YotiSDKDesign.json
+++ b/Specs/Carthage/YotiSDKDesign.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiSDKDesign.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiSDKDesign.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiSDKDesign.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiSDKDesign.zip",
 }

--- a/Specs/Carthage/YotiSDKDocument.json
+++ b/Specs/Carthage/YotiSDKDocument.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiSDKDocument.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiSDKDocument.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiSDKDocument.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiSDKDocument.zip",
 }

--- a/Specs/Carthage/YotiSDKNetwork.json
+++ b/Specs/Carthage/YotiSDKNetwork.json
@@ -1,3 +1,4 @@
 {
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiSDKNetwork.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiSDKNetwork.zip",
 }

--- a/Specs/Carthage/YotiSDKZoom.json
+++ b/Specs/Carthage/YotiSDKZoom.json
@@ -5,4 +5,5 @@
     "2.2.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.0/YotiSDKZoom.zip",
     "2.2.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.2.1/YotiSDKZoom.zip",
     "2.3.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.0/YotiSDKZoom.zip",
+    "2.3.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.3.1/YotiSDKZoom.zip",
 }


### PR DESCRIPTION
## Purpose
Support the [`v2.3.1`](https://github.com/getyoti/yoti-doc-scan-ios/releases/tag/v2.3.1) release:
- Update binary project specs for `Carthage`
- Update sample apps for `Carthage` and `CocoaPods`