### PR TITLE
[Release] DEP-196: v2.6.1

### DIFF
--- a/Samples/Carthage/Sample.xcodeproj/project.pbxproj
+++ b/Samples/Carthage/Sample.xcodeproj/project.pbxproj
@@ -330,7 +330,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.6.1;
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;
@@ -426,7 +426,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.6.1;
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;

--- a/Samples/CocoaPods/Sample.xcodeproj/project.pbxproj
+++ b/Samples/CocoaPods/Sample.xcodeproj/project.pbxproj
@@ -249,7 +249,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.6.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;
@@ -339,7 +339,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.0;
+				MARKETING_VERSION = 2.6.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;

--- a/Specs/Carthage/YotiCommon.json
+++ b/Specs/Carthage/YotiCommon.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiCommon.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiCommon.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiCommon.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiCommon.zip",
 }

--- a/Specs/Carthage/YotiDocumentCapture.json
+++ b/Specs/Carthage/YotiDocumentCapture.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiDocumentCapture.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiDocumentCapture.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiDocumentCapture.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiDocumentCapture.zip",
 }

--- a/Specs/Carthage/YotiFoundation.json
+++ b/Specs/Carthage/YotiFoundation.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiFoundation.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiFoundation.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiFoundation.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiFoundation.zip",
 }

--- a/Specs/Carthage/YotiNetwork.json
+++ b/Specs/Carthage/YotiNetwork.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiNetwork.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiNetwork.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiNetwork.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiNetwork.zip",
 }

--- a/Specs/Carthage/YotiSDKCommon.json
+++ b/Specs/Carthage/YotiSDKCommon.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiSDKCommon.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiSDKCommon.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKCommon.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKCommon.zip",
 }

--- a/Specs/Carthage/YotiSDKCore.json
+++ b/Specs/Carthage/YotiSDKCore.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiSDKCore.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiSDKCore.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKCore.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKCore.zip",
 }

--- a/Specs/Carthage/YotiSDKDesign.json
+++ b/Specs/Carthage/YotiSDKDesign.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiSDKDesign.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiSDKDesign.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKDesign.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKDesign.zip",
 }

--- a/Specs/Carthage/YotiSDKDocument.json
+++ b/Specs/Carthage/YotiSDKDocument.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiSDKDocument.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiSDKDocument.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKDocument.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKDocument.zip",
 }

--- a/Specs/Carthage/YotiSDKNetwork.json
+++ b/Specs/Carthage/YotiSDKNetwork.json
@@ -6,4 +6,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiSDKNetwork.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiSDKNetwork.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKNetwork.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKNetwork.zip",
 }

--- a/Specs/Carthage/YotiSDKZoom.json
+++ b/Specs/Carthage/YotiSDKZoom.json
@@ -11,4 +11,5 @@
     "2.4.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.4.1/YotiSDKZoom.zip",
     "2.5.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.5.0/YotiSDKZoom.zip",
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKZoom.zip",
+    "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKZoom.zip",
 }


### PR DESCRIPTION
## Purpose
Support the [`v2.6.1`](https://github.com/getyoti/yoti-doc-scan-ios/releases/tag/v2.6.1) release:
- Update binary project specs for `Carthage`
- Update sample apps for `Carthage` and `CocoaPods`