### PR TITLE
[Release] DEP-227: v2.7.0

### DIFF
--- a/Installation/Carthage/YotiSDKDocument+YotiSDKZoom/Cartfile
+++ b/Installation/Carthage/YotiSDKDocument+YotiSDKZoom/Cartfile
@@ -8,5 +8,5 @@ binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiSDKDocument.json"
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiDocumentCapture.json"
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiSDKZoom.json"
-github "BlinkID/blinkid-ios" "v5.8.0"
+github "BlinkID/blinkid-ios" "v5.9.0"
 github "apple/swift-protobuf" "1.15.0"

--- a/Installation/Carthage/YotiSDKDocument/Cartfile
+++ b/Installation/Carthage/YotiSDKDocument/Cartfile
@@ -7,5 +7,5 @@ binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiSDKCore.json"
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiSDKDocument.json"
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiDocumentCapture.json"
-github "BlinkID/blinkid-ios" "v5.8.0"
+github "BlinkID/blinkid-ios" "v5.9.0"
 github "apple/swift-protobuf" "1.15.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Integrating with our SDK allows a user of your app to take a photo of their docu
 In order to integrate with our SDK, a working infrastructure is needed (see [developers.yoti.com](https://developers.yoti.com/yoti-doc-scan/yoti-doc-scan-integration-introduction) for more details).
 
 ## Requirements
-- iOS 11.0+
+- iOS 12.0+
 - Swift 5.3+
 
 ## Installation
@@ -20,7 +20,7 @@ Make sure you've installed and are running the latest version of:
 ### CocoaPods
 Add the following to your [`Podfile`](https://guides.cocoapods.org/using/the-podfile.html) and run `pod install` from its directory:
 ```bash
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'TargetName' do
   use_frameworks!

--- a/Samples/Carthage/Cartfile
+++ b/Samples/Carthage/Cartfile
@@ -8,5 +8,5 @@ binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiSDKDocument.json"
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiDocumentCapture.json"
 binary "https://raw.githubusercontent.com/getyoti/yoti-doc-scan-ios/master/Specs/Carthage/YotiSDKZoom.json"
-github "BlinkID/blinkid-ios" "v5.8.0"
+github "BlinkID/blinkid-ios" "v5.9.0"
 github "apple/swift-protobuf" "1.15.0"

--- a/Samples/Carthage/Sample.xcodeproj/project.pbxproj
+++ b/Samples/Carthage/Sample.xcodeproj/project.pbxproj
@@ -328,9 +328,9 @@
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.2;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;
@@ -424,9 +424,9 @@
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.2;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;

--- a/Samples/CocoaPods/Podfile
+++ b/Samples/CocoaPods/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'Sample' do
   use_frameworks!

--- a/Samples/CocoaPods/Sample.xcodeproj/project.pbxproj
+++ b/Samples/CocoaPods/Sample.xcodeproj/project.pbxproj
@@ -247,9 +247,9 @@
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.2;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;
@@ -337,9 +337,9 @@
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Sample/SupportingFiles/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 2.6.2;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yoti.mobile.ios.sdk.yds.Sample;

--- a/Specs/Carthage/YotiCommon.json
+++ b/Specs/Carthage/YotiCommon.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiCommon.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiCommon.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiCommon.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiCommon.zip",
 }

--- a/Specs/Carthage/YotiDocumentCapture.json
+++ b/Specs/Carthage/YotiDocumentCapture.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiDocumentCapture.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiDocumentCapture.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiDocumentCapture.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiDocumentCapture.zip",
 }

--- a/Specs/Carthage/YotiFoundation.json
+++ b/Specs/Carthage/YotiFoundation.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiFoundation.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiFoundation.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiFoundation.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiFoundation.zip",
 }

--- a/Specs/Carthage/YotiNetwork.json
+++ b/Specs/Carthage/YotiNetwork.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiNetwork.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiNetwork.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiNetwork.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiNetwork.zip",
 }

--- a/Specs/Carthage/YotiSDKCommon.json
+++ b/Specs/Carthage/YotiSDKCommon.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKCommon.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKCommon.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiSDKCommon.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiSDKCommon.zip",
 }

--- a/Specs/Carthage/YotiSDKCore.json
+++ b/Specs/Carthage/YotiSDKCore.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKCore.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKCore.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiSDKCore.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiSDKCore.zip",
 }

--- a/Specs/Carthage/YotiSDKDesign.json
+++ b/Specs/Carthage/YotiSDKDesign.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKDesign.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKDesign.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiSDKDesign.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiSDKDesign.zip",
 }

--- a/Specs/Carthage/YotiSDKDocument.json
+++ b/Specs/Carthage/YotiSDKDocument.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKDocument.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKDocument.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiSDKDocument.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiSDKDocument.zip",
 }

--- a/Specs/Carthage/YotiSDKNetwork.json
+++ b/Specs/Carthage/YotiSDKNetwork.json
@@ -8,4 +8,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKNetwork.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKNetwork.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiSDKNetwork.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiSDKNetwork.zip",
 }

--- a/Specs/Carthage/YotiSDKZoom.json
+++ b/Specs/Carthage/YotiSDKZoom.json
@@ -13,4 +13,5 @@
     "2.6.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.0/YotiSDKZoom.zip",
     "2.6.1": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.1/YotiSDKZoom.zip",
     "2.6.2": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.6.2/YotiSDKZoom.zip",
+    "2.7.0": "https://github.com/getyoti/yoti-doc-scan-ios/releases/download/v2.7.0/YotiSDKZoom.zip",
 }


### PR DESCRIPTION
## Purpose
Support the [`v2.7.0`](https://github.com/getyoti/yoti-doc-scan-ios/releases/tag/v2.7.0) release:
- Update `README.md`
- Update installation files for `Carthage`
- Update binary project specs for `Carthage`
- Update sample apps for `Carthage` and `CocoaPods`